### PR TITLE
Replace `$_POST` superglobal with `$request->post()` method

### DIFF
--- a/src/Installer/Form/InstallerFormHandler.php
+++ b/src/Installer/Form/InstallerFormHandler.php
@@ -18,13 +18,13 @@ class InstallerFormHandler
      * @param InstallerFormBuilder     $builder
      * @param InstallerModuleInstaller $moduleInstaller
      */
-    public function handle(InstallerFormBuilder $builder, InstallerModuleInstaller $moduleInstaller)
+    public function handle(Request $request, InstallerFormBuilder $builder, InstallerModuleInstaller $moduleInstaller)
     {
         if ($builder->hasFormErrors()) {
             return;
         }
 
-        $moduleInstaller->install($_POST);
+        $moduleInstaller->install($request->post());
 
         $builder->setFormResponse(redirect('installer/install'));
     }


### PR DESCRIPTION
This PR replaces references to PHP superglobal $_POST in `Anomaly\InstallerModule\Installer\Form\InstallerFormHandler` with `$request->post()`

Issue reference: pyrocms/pyrocms#4776.